### PR TITLE
feat: add Mova chain refs (mainnet + testnet)

### DIFF
--- a/proto/common.proto
+++ b/proto/common.proto
@@ -186,6 +186,7 @@ enum ChainRef {
   CHAIN_KITE__MAINNET = 1166;
   CHAIN_HUMANITY__MAINNET = 1167;
   CHAIN_APTOS__MAINNET = 1168;
+  CHAIN_MOVA__MAINNET = 1170;
 
   // Testnets start with 10_000
   CHAIN_ETHEREUM__MORDEN = 10001;
@@ -387,6 +388,7 @@ enum ChainRef {
   CHAIN_BOTANIX__TESTNET = 10201;
   CHAIN_HUMANITY__TESTNET = 10202;
   CHAIN_APTOS__TESTNET = 10203;
+  CHAIN_MOVA__TESTNET = 10205;
 
   // Virtual chains (no real blockchain)
   CHAIN_LAMBDA__VIRTUAL = 100000; // P2P Lambda REST API synthetic provider


### PR DESCRIPTION
Adds `CHAIN_MOVA__MAINNET = 1170` and `CHAIN_MOVA__TESTNET = 10205` to the `ChainRef` enum, matching the grpcIds already assigned in `drpcorg/public` chains.yaml ([drpcorg/public#240](https://github.com/drpcorg/public/pull/240)).

**Why:** without the enum entry dshackle cannot expose the chain over gRPC at all. Both `Describe.kt:38` and `SubscribeChainStatus.kt:31` filter with `Common.ChainRef.forNumber(it.id) != null`, and `forNumber(1170)` returns null in Java/Kotlin protobuf — so a perfectly healthy upstream is silently dropped from the provider's supported-chain list and from chain-status subscriptions.

Observed in prod: after [drpcorg/dshackle#882](https://github.com/drpcorg/dshackle/pull/882) (chains.yaml bump) was released, `dshackle_upstreams_availability_status{upstream="mova-nodecore"}` is `1` in all three public-multiregion regions, yet the aggregator's per-provider chain list has no mova:

```
success provider - drpc-public-multiregion (1 conns), supported chains -
[holesky … morph morph-hoodi … abcore bsquared stable humanity humanity-testnet]
```

**Numbering:** intentionally not sequential. 1170/10205 are what chains.yaml declares and what prod already runs on; 1169 and 10204 have never been assigned to any chain (checked the full chains.yaml history) and stay free.

Validated with `protoc --proto_path=proto --descriptor_set_out=/dev/null proto/common.proto`.
